### PR TITLE
plugin, config: add optional `maxmind_license_key` setting

### DIFF
--- a/sopel_iplookup/config.py
+++ b/sopel_iplookup/config.py
@@ -1,7 +1,11 @@
 """Configuration section for plugin."""
 from __future__ import annotations
 
-from sopel.config.types import FilenameAttribute, StaticSection  # type: ignore
+from sopel.config.types import (
+    FilenameAttribute,
+    SecretAttribute,
+    StaticSection,
+)  # type: ignore
 
 
 class GeoipSection(StaticSection):
@@ -10,4 +14,12 @@ class GeoipSection(StaticSection):
 
     If the given value is not an absolute path, it will be interpreted relative
     to the directory containing the config file with which Sopel was started.
+    """
+
+    maxmind_license_key = SecretAttribute(
+        'maxmind_license_key', default='JXBEmLjOzislFnh4')
+    """License key for downloading GeoIP database files from MaxMind.
+
+    The plugin ships with a default key, but this option is available in case
+    overriding the inbuilt key is desired or required.
     """

--- a/sopel_iplookup/plugin.py
+++ b/sopel_iplookup/plugin.py
@@ -31,10 +31,13 @@ def configure(config: Config):
     | name | example | purpose |
     | ---- | ------- | ------- |
     | GeoIP\\_db\\_path | /home/sopel/GeoIP/ | Path to the GeoIP database files |
+    | maxmind_license_key | random_ascii_str | License key for DB downloads |
     """
     config.define_section('ip', GeoipSection)
     config.ip.configure_setting('GeoIP_db_path',
                                 'Path of the GeoIP db files')
+    config.ip.configure_setting('maxmind_license_key',
+                                'Custom MaxMind license key')
 
 
 def setup(bot: Sopel):
@@ -87,7 +90,10 @@ def _find_geoip_db(bot: SopelWrapper):
     LOGGER.info('Downloading GeoIP database')
     bot.say('Downloading GeoIP database, please wait...')
 
-    common_params = {'license_key': 'JXBEmLjOzislFnh4', 'suffix': 'tar.gz'}
+    common_params = {
+        'license_key': config.ip.maxmind_license_key,
+        'suffix': 'tar.gz',
+    }
     base_url = 'https://download.maxmind.com/app/geoip_download'
     geolite_urls = []
 


### PR DESCRIPTION
As we have done with other plugins that ship with a built-in API key of some kind (e.g. sopel-reddit), it's always preferable to include the ability to override that built-in key before it's actually needed, lest a key revocation break all installed plugin copies until an emergency release can be published with configuration support.

I'm aware that there are some flake8 errors in this code as it currently exists (maybe @SnoopJ uses a custom user/global config with a non-default line length?) but have reserved fixing those for a separate PR if necessary.