### PR TITLE
plugin, config: make license key entirely optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,57 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,27 @@ The recommended way to install this plugin is to use ``pip``::
 Note that this plugin requires Python 3.7+ and Sopel 7.1+. It won't work on
 Python versions that are not supported by the version of Sopel you are using.
 
+Configure
+=========
+
+``sopel-iplookup`` can be configured by invoking Sopel's interactive wizard::
+
+    $ sopel-plugins configure iplookup
+    Configure Sopel GeoIP Lookup Plugin
+    Please consult sopel-iplookup's README to learn about its settings.
+
+    Path to existing GeoIP db files (leave empty to auto download): 
+    MaxMind license key (optional): (hidden input)
+
+If your OS distribution has GeoIP database files installed already, you can
+provide a filesystem path to the folder where they are stored. The plugin will
+auto-download the database files if it cannot find them locally.
+
+By default, GeoIP database downloads will use an automated mirror on GitHub. You
+can optionally provide your own MaxMind license key and the plugin will download
+directly from them—useful in case the mirror breaks, or if you would simply like
+to get database files from the source.
+
 Notes
 =====
 

--- a/README.rst
+++ b/README.rst
@@ -30,14 +30,14 @@ Configure
     Path to existing GeoIP db files (leave empty to auto download): 
     MaxMind license key (optional): (hidden input)
 
-If your OS distribution has GeoIP database files installed already, you can
-provide a filesystem path to the folder where they are stored. The plugin will
-auto-download the database files if it cannot find them locally.
+By default, ``sopel-iplookup`` will look in a few standard locations for GeoIP
+database files. If it can't find existing database files, it will download them
+from an automated mirror on GitHub.
 
-By default, GeoIP database downloads will use an automated mirror on GitHub. You
-can optionally provide your own MaxMind license key and the plugin will download
-directly from them—useful in case the mirror breaks, or if you would simply like
-to get database files from the source.
+You can optionally provide your own MaxMind license key, and the plugin will
+download directly from them instead. Alternatively, if your OS distribution
+already has GeoIP database files kept up-to-date by the system package manager,
+you can provide the path where those files are stored.
 
 Notes
 =====

--- a/sopel_iplookup/config.py
+++ b/sopel_iplookup/config.py
@@ -16,10 +16,9 @@ class GeoipSection(StaticSection):
     to the directory containing the config file with which Sopel was started.
     """
 
-    maxmind_license_key = SecretAttribute(
-        'maxmind_license_key', default='JXBEmLjOzislFnh4')
+    maxmind_license_key = SecretAttribute('maxmind_license_key', default=None)
     """License key for downloading GeoIP database files from MaxMind.
 
-    The plugin ships with a default key, but this option is available in case
-    overriding the inbuilt key is desired or required.
+    The plugin downloads from a keyless source by default, but this option is
+    available if you wish to download the files using your own MaxMind account.
     """

--- a/sopel_iplookup/plugin.py
+++ b/sopel_iplookup/plugin.py
@@ -95,7 +95,7 @@ def _find_geoip_db(bot: SopelWrapper):
                 LOGGER.warning(
                     'GeoIP path configured but DB not found in %s', str(pth))
 
-    LOGGER.info('Downloading GeoIP database')
+    LOGGER.info('Downloading GeoIP database files')
     bot.say('Downloading GeoIP database, please wait...')
 
     geolite_urls = []
@@ -146,6 +146,7 @@ def _find_geoip_db(bot: SopelWrapper):
             # (the `suffix=tar.gz` parameter)
             _decompress_targz(full_path, config.core.homedir)
 
+    LOGGER.info('GeoIP database downloads complete')
     return config.core.homedir
 
 


### PR DESCRIPTION
Tin. Built on #4, but takes it to a new extreme as discussed in https://github.com/sopel-irc/sopel-iplookup/issues/3#issuecomment-1989629080.

Motivated by some joker on AWS repeatedly exhausting our account's daily download quota, spamming me with email notifications from MM, plus breaking any new installs of Sopel 7.x and this standalone plugin for 8.x.

Since the daily quota appears to be around 32 downloads, the existing download solution with an inbuilt key was never going to scale particularly well anyway. We might as well prepare now.