### PR TITLE
meta: add a NEWS file to hold changelogs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,7 @@
+Changelog
+=========
+
+1.0.0
+-----
+
+Initial release. Replaces ``ip`` plugin formerly shipped as part of ``sopel``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ platforms = ["Linux x86, x86-64"]
 include = ["sopel_iplookup", "sopel_iplookup.*"]
 namespaces = false
 
+[tool.setuptools.dynamic]
+readme = { file=["README.rst", "NEWS"], content-type="text/x-rst" }
+
 [project]
 name = "sopel-iplookup"
 version = "1.0.0"
@@ -32,7 +35,7 @@ authors = [
   { name="SnoopJ", email="snoopjedi@gmail.com" },
 ]
 
-readme = "README.rst"
+dynamic = ["readme"]
 license = { text="EFL-2.0" }
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
Kept README.rst as reStructuredText for now, though converting it to Markdown briefly came up (in #5).

Uploaded a package to TestPyPI with this change: https://test.pypi.org/project/sopel-iplookup/1.0.1.dev0/
_Note: Version number is not modified by this PR; a 1.0.0 test release already existed, that's all._