### PR TITLE
meta: add automated release workflow using PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/trusted-publishing.yml
+++ b/.github/workflows/trusted-publishing.yml
@@ -1,0 +1,29 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450


### PR DESCRIPTION
Trusted Publishing has proved to be very convenient vs. manual publishing with `twine` or managing per-package tokens/secrets in GitHub Actions settings. Pretty much every plugin repo I've touched in the last month or two—org-owned _and_ personal—has this set up, because it's just that satisfying to get running. 😁 (This `trusted-publishing.yml` is actually a direct copy from `wget https://github.com/sopel-irc/sopel-twitter/raw/master/.github/workflows/trusted-publishing.yml`, since I've already verified that it works.)

Since I have PyPI access for this package, I preauthorized the owner-repo-workflow-environment combination on that end.

Typically my process is to create a "Release x.y.z" commit with the new release's `NEWS` entry and version-number bump, then copy the changelog info to a new Release on GH and publish it as a new `vx.y.z` tag. Doesn't mean you have to do it that way (though I do request that you keep the same tag name format for consistency with other projects under @sopel-irc). 😸