### PR TITLE
Update trusted publishing workflow

### DIFF
--- a/.github/workflows/trusted-publishing.yml
+++ b/.github/workflows/trusted-publishing.yml
@@ -3,16 +3,14 @@ name: Upload Python Package
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  upload:
+  build:
     runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      id-token: write
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -22,8 +20,47 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build
+        python -m pip install --user -r requirements-dev.txt
     - name: Build package
-      run: python -m build
+      run: |
+        make build
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: built-distributions
+        path: dist/
+
+  upload:
+    if: ${{ github.event_name == 'release' }}
+    needs: build
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: built-distributions
+        path: dist/
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
+
+
+  test-upload:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    needs: build
+    runs-on: ubuntu-latest
+    environment: testrelease
+    permissions:
+      id-token: write
+    steps:
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: built-distributions
+        path: dist/
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
+      with:
+        repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Steals improvements from sopel-unicode (manual dispatch to publish on testpypi for preflight) and elsewhere (privilege separation between build and release stages).

Realized this was getting a little outdated thanks to our collaboration on a new plugin package.