### PR TITLE
Makefile: bring back tweaks from `sopel-wikimedia`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: qa quality pylint pyroma
 
 quality:
-	isort sopel_iplookup
+	isort -c sopel_iplookup
 	flake8 sopel_iplookup
 	mypy sopel_iplookup
 
@@ -16,8 +16,9 @@ qa: quality pylint pyroma
 .PHONY: develop build
 
 develop:
-	pip install -r requirements.txt
-	python setup.py develop
+	python -m pip install -U pip
+	python -m pip install -U requirements.txt
+	python -m pip install -e .
 
 build:
 	rm -rf build/ dist/


### PR DESCRIPTION
This Makefile got adapted for use in a new plugin package, and code
review there turned up a couple things that could be done better.

  1. Run `isort` in check-only mode, so it doesn't actually fix the errors. Important for CI usage.
  2. Upgrade `pip` before installing dev requirements.
  3. Install as an editable package instead of using the old `python setup.py develop` style.
